### PR TITLE
fix(dependencies): remove standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,7 @@
     "@adonisjs/ignitor": "^1.0.12",
     "@adonisjs/lucid": "^4.0.20"
   },
-  "devDependencies": {
-    "standard": "^10.0.3"
-  },
-  "standard": {
-    "globals": [
-      "use",
-      "make"
-    ]
-  },
+  "devDependencies": {},
   "autoload": {
     "App": "./app"
   }


### PR DESCRIPTION
Hey 👋

I think Adonis shouldn't force the use of `standard` in "customer" application.