### PR TITLE
Only re-hash if password is dirty

### DIFF
--- a/app/Models/Hooks/User.js
+++ b/app/Models/Hooks/User.js
@@ -14,7 +14,7 @@ const UserHook = module.exports = {}
  * @return {void}
  */
 UserHook.hashPassword = async (userInstance) => {
-  if (userInstance.password) {
+  if (userInstance.dirty.password) {
     userInstance.password = await Hash.make(userInstance.password)
   }
 }


### PR DESCRIPTION
This fixes a bug where future user saves would re-hash the password again, and thus having double hashed password and user is unable to login.